### PR TITLE
Did some tweaking so it would compile

### DIFF
--- a/src/node-kdtree.cc
+++ b/src/node-kdtree.cc
@@ -8,7 +8,6 @@
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -23,7 +22,7 @@ using namespace node;
 void freeNodeData(void *data){
   if (data != NULL) {
     // Release this persistent handle's storage cell
-    Persistent<Value> hData = Persistent<Value>::Persistent((Value *)data);
+    Persistent<Value> hData = Persistent<Value>((Value *)data);
     hData.Dispose();
   }
 }
@@ -118,7 +117,7 @@ class KDTree : public ObjectWrap {
 
         // Append data element, if present
         if (pdata != NULL) {
-          Persistent<Value> hdata = Persistent<Value>::Persistent((Value *)pdata);
+          Persistent<Value> hdata = Persistent<Value>((Value *)pdata);
           rv->Set(dim_, hdata); 
         }
 
@@ -164,7 +163,7 @@ class KDTree : public ObjectWrap {
 
         // Append data element, if present
         if (pdata != NULL) {
-          Persistent<Value> hdata = Persistent<Value>::Persistent((Value *)pdata);
+          Persistent<Value> hdata = Persistent<Value>((Value *)pdata);
           rvItem->Set(dim_, hdata); 
         }
 


### PR DESCRIPTION
node_events.h was removed a little while ago I guess (https://github.com/naked/node-kdtree/pull/new/master)

then I was getting errors like so:

```
../src/node-kdtree.cc: In function 'void freeNodeData(void*)':
../src/node-kdtree.cc:26:74: error: cannot call constructor 'v8::Persistent<v8::Value>::Persistent' directly [-fpermissive]
../src/node-kdtree.cc:26:74: error:   for a function-style cast, remove the redundant '::Persistent' [-fpermissive]
```

so I just followed the compiler's instructions :P
This is my first pull request, hopefully I did it right.  Cheers
_edit_ sorry about having two usernames... I have no idea how that happened
