### PR TITLE
Correct to work with node >=v0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=v4.6.x"
+    "node": ">=v0.8.x"
   },
   "dependencies": {
     "nan": "2.4.x"


### PR DESCRIPTION
Switched to Nan version of objects for backwards compatibility. Change
all occurrences of Handle to Value, Handle was deprecated in v8 a while
back. Tested and working on v0.8.28, v0.10.48, v0.12.17, v4.6.2, and v6.6.0.